### PR TITLE
Fix gem issues and update examples

### DIFF
--- a/PdfMaster.gemspec
+++ b/PdfMaster.gemspec
@@ -28,13 +28,13 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.glob("{lib,pdf_modifier}/**/*", File::FNM_DOTMATCH).reject do |f|
-    f.match(%r{^(test|spec|features|bin|.git|.github|appveyor|Gemfile|PdfMaster-.*\.gem)}) ||
+  spec.files = Dir.glob("{bin,lib}/**/*", File::FNM_DOTMATCH).reject do |f|
+    f.match(%r{^(test|spec|features|.git|.github|appveyor|Gemfile|PdfMaster-.*\.gem)}) ||
     File.directory?(f)
   end
 
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 3.3.0"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ PdfMaster::Modify.remove_page('input.pdf', 1)
 ### Rotating a Page
 
 ```ruby
-PdfMaster::Modify.rotate_page('input.pdf', 1, 90)
+PdfMaster::Modify.rotate_page('input.pdf', 90, 1)
 ```
 
 ### Duplicating a Page

--- a/lib/PdfMaster.rb
+++ b/lib/PdfMaster.rb
@@ -16,11 +16,11 @@ require_relative 'PdfMaster/editor'
 require_relative 'PdfMaster/converter'
 
 module PdfMaster
-  # class Error < Standard8Error; end
+  # Custom errors live under PdfMaster::Errors
   include PdfMaster::Errors
 
   def self.method_missing(method_name, *args, &block)
-    puts "Calling: #{method_name} with arguments: #{args.inspect}"
+    Logger.log("Calling: #{method_name} with arguments: #{args.inspect}")
 
     Validator.validate_pdf(args.first) if args.any?
 

--- a/lib/PdfMaster/converter.rb
+++ b/lib/PdfMaster/converter.rb
@@ -4,10 +4,11 @@ module PdfMaster
 
       def image_to_pdf(image_paths, output_pdf)
         Logger.log("Converting images #{image_paths} to PDF: #{output_pdf}")
+        images = Array(image_paths)
         pdf = Prawn::Document.new
-        Array(image_paths).each do |image|
+        images.each_with_index do |image, index|
           pdf.image image, fit: [500, 700]
-          pdf.start_new_page unless image == image_paths.last
+          pdf.start_new_page unless index == images.length - 1
         end
         pdf.render_file(output_pdf)
         Logger.log("Image to PDF conversion completed: #{output_pdf}")

--- a/lib/PdfMaster/utilities.rb
+++ b/lib/PdfMaster/utilities.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module PdfMaster
   module Utilities
     UPLOADS_DIR = 'public/uploads'.freeze

--- a/spec/PdfMaster_spec.rb
+++ b/spec/PdfMaster_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe PdfMaster do
     end
 
     it 'rotates a page in a PDF' do
-      expect { PdfMaster::Modify.rotate_page(sample_pdf, 1, 90) }.not_to raise_error
+      expect { PdfMaster::Modify.rotate_page(sample_pdf, 90, 1) }.not_to raise_error
     end
 
     it 'duplicates a page in a PDF' do


### PR DESCRIPTION
## Summary
- point gemspec to bin executables and remove stray folders
- log method missing calls instead of printing
- require `fileutils` where FileUtils is used
- fix PDF image loop logic
- rotate page arguments example

## Testing
- `bundle exec rspec` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68808776a130832295f07f42b371d61c