### PR TITLE
Improve code standards

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "PdfMaster"

--- a/lib/PdfMaster.rb
+++ b/lib/PdfMaster.rb
@@ -1,17 +1,19 @@
-require "hexapdf"
-require "combine_pdf"
-require "prawn"
+# frozen_string_literal: true
+
+require 'hexapdf'
+require 'combine_pdf'
+require 'prawn'
 require 'mini_magick'
 require 'shellwords'
-require "pdfkit"
+require 'pdfkit'
 
-require_relative "PdfMaster/version"
+require_relative 'PdfMaster/version'
 require_relative 'PdfMaster/errors'
-require_relative "PdfMaster/validator"
+require_relative 'PdfMaster/validator'
 require_relative 'PdfMaster/logger'
 require_relative 'PdfMaster/base'
 
-require_relative "PdfMaster/modify"
+require_relative 'PdfMaster/modify'
 require_relative 'PdfMaster/editor'
 require_relative 'PdfMaster/converter'
 

--- a/lib/PdfMaster/base.rb
+++ b/lib/PdfMaster/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'utilities'
 
 module PdfMaster

--- a/lib/PdfMaster/converter.rb
+++ b/lib/PdfMaster/converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PdfMaster
   class Converter
     class << self

--- a/lib/PdfMaster/editor.rb
+++ b/lib/PdfMaster/editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'logger'
 
 module PdfMaster

--- a/lib/PdfMaster/errors.rb
+++ b/lib/PdfMaster/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PdfMaster
   module Errors
     class PdfError < StandardError; end

--- a/lib/PdfMaster/logger.rb
+++ b/lib/PdfMaster/logger.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 module PdfMaster
   class Logger
     def self.instance
-      @logger ||= begin
+      @loggers ||= begin
         file_logger = ::Logger.new(File.join(Dir.pwd, 'pdf_master.log'), 'daily')
         file_logger.level = ::Logger::INFO
-        
+
         console_logger = ::Logger.new(STDOUT)
         console_logger.level = ::Logger::INFO
 
-        [file_logger, console_logger]
+        [file_logger, console_logger].freeze
       end
     end
 

--- a/lib/PdfMaster/modify.rb
+++ b/lib/PdfMaster/modify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'logger'
 
 module PdfMaster
@@ -251,7 +253,7 @@ module PdfMaster
         move_last: ->(pages, *indices) { move_pages(pages, indices, :last) },
         swap: ->(pages, index1, index2) { pages[index1 - 1], pages[index2 - 1] = pages[index2 - 1], pages[index1 - 1] },
         move_to: ->(pages, from, to) { pages.insert(to - 1, pages.delete_at(from - 1)) }
-      }
+      }.freeze
 
       def rearrange_pages(input_pdf, action, *args)
         Logger.log("Rearranging pages in #{input_pdf} using action: #{action} with args: #{args}")

--- a/lib/PdfMaster/utilities.rb
+++ b/lib/PdfMaster/utilities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 module PdfMaster
@@ -31,10 +33,11 @@ module PdfMaster
     end
 
     def calculate_position(position, width, height, x = nil, y = nil)
-      return POSITIONS[position].call(width, height) if position && POSITIONS.key?(position)
-      return [x, y] if x && y # Use custom coordinates
+      pos_key = position&.to_s
+      return POSITIONS[pos_key].call(width, height) if pos_key && POSITIONS.key?(pos_key)
+      return [x, y] if x && y
 
-      [0, 0] # Default to (0,0) if nothing is provided
+      [0, 0]
     end
   end
 end

--- a/lib/PdfMaster/validator.rb
+++ b/lib/PdfMaster/validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PdfMaster
   class Validator
     def self.validate_pdf(pdf_path)

--- a/lib/PdfMaster/version.rb
+++ b/lib/PdfMaster/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PdfMaster
   VERSION = "0.1.0"
 end


### PR DESCRIPTION
## Summary
- add `# frozen_string_literal: true` to ruby files
- freeze the ACTIONS hash
- improve logger initialization and freeze loggers
- allow symbol keys in `calculate_position`

## Testing
- `bundle exec rspec --format doc` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68808b862d18832280d4312396f3408f