### PR TITLE
Fix watermark opacity and improve hyperlink rendering

### DIFF
--- a/lib/PdfMaster/converter.rb
+++ b/lib/PdfMaster/converter.rb
@@ -26,14 +26,18 @@ module PdfMaster
         output_prefix = File.join(output_folder, "page")
         command = "pdftoppm -png #{Shellwords.escape(input_pdf)} #{Shellwords.escape(output_prefix)}"
 
-        # Execute the command
+        unless system('which pdftoppm > /dev/null 2>&1')
+          Logger.log('pdftoppm not found in PATH')
+          raise 'pdftoppm command is required for PDF to image conversion'
+        end
+
         success = system(command)
 
         if success
           Logger.log("Successfully converted PDF pages to images in #{output_folder}")
         else
-          Logger.log("Error converting PDF to images.")
-          raise "PDF to Image conversion failed."
+          Logger.log('Error converting PDF to images.')
+          raise 'PDF to Image conversion failed.'
         end
       end
 

--- a/lib/PdfMaster/editor.rb
+++ b/lib/PdfMaster/editor.rb
@@ -76,7 +76,9 @@ module PdfMaster
           generate_overlay_pdf(temp_pdf) do |pdf|
             apply_font(pdf, font_settings)  # Apply custom or default font settings
             pdf.fill_color 'CCCCCC'
-            pdf.text_box watermark_text, at: [x, y], size: 50, rotate: 45, opacity: 0.3
+            pdf.transparent(0.3) do
+              pdf.text_box watermark_text, at: [x, y], size: 50, rotate: 45
+            end
           end
         end
         Logger.log("Watermark added successfully.")
@@ -126,7 +128,11 @@ module PdfMaster
         process_pdf(pdf_path, 'hyperlink', page) do |target_page, temp_pdf|
           generate_overlay_pdf(temp_pdf) do |pdf|
             apply_font(pdf, font_settings)  # Apply custom or default font settings
-            pdf.text_box link_text, at: [x, y], size: 12, link: url, underline: true, color: '0000FF'
+            pdf.formatted_text_box(
+              [{ text: link_text, styles: [:underline], color: '0000FF', link: url }],
+              at: [x, y],
+              size: 12
+            )
           end
         end
         Logger.log("Hyperlink added successfully.")


### PR DESCRIPTION
## Summary
- fix watermark opacity handling using `transparent`
- render hyperlinks with `formatted_text_box`
- validate `pdftoppm` presence before converting PDFs to images

## Testing
- `bundle exec rspec` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837e9a11008322a4244c4b1419621b